### PR TITLE
GEN-520 fix local docker mount point

### DIFF
--- a/scripts/docker/run/telegraf.sh
+++ b/scripts/docker/run/telegraf.sh
@@ -11,7 +11,7 @@ done
 
 # Telegraf
 # TODO: display docker stats in influx
-localconf="/$HOME/src/logical-replication-demo/telegraf.conf"
+localconf="/$HOME/src/production-at-home/telegraf.conf"
 docker buildx build -t telegraf -f Dockerfile.telegraf .
 # Apparently, the network needs to be created before the container is run.
 docker network ls | grep -q "pubsub_network" || docker network create pubsub_network


### PR DESCRIPTION
https://doolin.atlassian.net/browse/GEN-520

Repository and local directory name changed to production-at-home, which needs to change in the docker script.

# Pull Request

## Description
Please include a brief description of the changes made in this PR.

## Jira Ticket
- [Jira Ticket](link_to_jira_ticket)

## Checklist
- [x] Linked to a Jira ticket.

